### PR TITLE
feat(ipc): M5 — GPS time + position bridge Core 1 → Core 0

### DIFF
--- a/docs/bringup/m5-gps-ipc-test-plan.md
+++ b/docs/bringup/m5-gps-ipc-test-plan.md
@@ -1,0 +1,209 @@
+# M5 GPS IPC Bridge — Hardware Test Plan
+
+**Milestone:** M5 GPS time + position propagation Core 1 → Core 0  
+**Date:** 2026-05-02  
+**Branch:** `dev-Sblzm`
+
+---
+
+## Summary
+
+Core 1 `gps_task` now writes structured `IpcGpsFixSlot` snapshots into the
+shared-SRAM `IpcGpsBuf` double-buffer.  Core 0 `IpcGpsConsumer` (1 Hz
+OSThread) reads the most-recently-published slot and calls:
+- `perhapsSetRTC(RTCQualityGPS, &tv)` — disciplines the Meshtastic wall clock
+- `nodeDB->setLocalPosition(pos)` — triggers `PositionModule::runOnce()` to
+  broadcast position to the mesh
+
+The real Teseo driver path is gated behind `#ifndef MOKYA_GPS_DUMMY_NMEA`.
+For initial hardware testing, use the dummy injector
+(`-DMOKYA_GPS_DUMMY_NMEA=ON` in Core 1's CMake config); it fires a
+`IpcGpsFixSlot` at 1 Hz with fixed Taipei coordinates
+(25.052103 N / 121.574039 E) and a monotonically-incrementing Unix epoch
+anchored to 2026-04-26 00:00:00 UTC.
+
+---
+
+## Prerequisites
+
+1. Dual-image firmware flashed via J-Link:
+   ```sh
+   bash scripts/build_and_flash.sh
+   ```
+   or independently:
+   ```sh
+   # Core 0 only
+   python -m platformio run -e rp2350b-mokya -d firmware/core0/meshtastic
+   # Core 1 only (with dummy NMEA enabled)
+   cmake -DMOKYA_GPS_DUMMY_NMEA=ON ...
+   bash scripts/build_and_flash.sh --core1
+   ```
+2. J-Link Ultra V6 connected via SWD.
+3. Host machine with `python -m meshtastic` (v2.7.8) available.
+
+---
+
+## Test 1 — IpcGpsBuf sanity via SWD (no serial required)
+
+Verify that Core 1's dummy injector is writing structured fix slots into
+shared SRAM at `g_ipc_shared.gps_buf`.
+
+### Procedure
+
+1. Power-cycle or reset the board.
+2. Wait ≥ 2 seconds for the GPS dummy task to have written at least two slots.
+3. Open a J-Link Commander session (device `RP2350_M33_0`, speed 4000):
+   ```
+   connect
+   h
+   ```
+4. Read `write_idx` (first byte of `IpcGpsBuf._pad` is at +48+1 = offset 49
+   from the start of `gps_buf`; but `write_idx` is at offset 48 of the struct):
+   ```
+   ; IpcSharedSram base = 0x2007A000
+   ; gps_buf offset = boot_handshake(28) + wd_pause(4) + ring_ctrl(3×32)
+   ;                + ring_slots(3×80×264) + _tail_pad_pre(1788)
+   ; = 28+4+96+63360+1788 = 65276 = 0xFF3C
+   ; gps_buf start = 0x2007A000 + 0xFF3C = 0x2007FF3C  (verify via map file)
+   mem8 <gps_buf_addr> 1          ; read write_idx byte
+   ```
+   The address can be pinned from the map:
+   ```sh
+   grep "g_ipc_shared" firmware/core0/meshtastic/.pio/build/rp2350b-mokya/firmware*.map
+   ```
+5. Read 8 bytes of `slot[write_idx ^ 1]` (the published slot):
+   ```
+   mem32 <gps_buf_addr+slot_offset> 4
+   ```
+   Expected (`slot[0]` if `write_idx=1`, `slot[1]` if `write_idx=0`):
+   - `unix_epoch` ≈ `0x67EC9A00` + seconds-since-boot (little-endian u32)
+   - `lat_e7` = `0x0EED81C6` (250521030 = 25.052103 × 1e7)
+   - `lon_e7` = `0x486AFC46` (1215740390 = 121.574039 × 1e7)
+   - `altitude_mm` = `0x0000C350` (50000 = 50 m)
+
+### Pass criteria
+- `write_idx` is 0 or 1 (not 255 = uninitialised).
+- `unix_epoch` ≠ 0.
+- `lat_e7` and `lon_e7` match the expected constants above.
+- Repeated reads (≥ 3 s apart) show `unix_epoch` incrementing by ~3
+  (one per second, three seconds elapsed).
+
+---
+
+## Test 2 — `meshtastic --info` reports GPS coordinates
+
+Verify that Core 0 `IpcGpsConsumer` is propagating the fix to `nodeDB` and
+that the Meshtastic CLI reflects the position.
+
+### Procedure
+
+1. Flash both cores with `bash scripts/build_and_flash.sh`.
+2. Wait ≥ 5 s for USB CDC to enumerate and the position thread to fire at
+   least once.
+3. Run:
+   ```sh
+   python -m meshtastic --port <COMxx> --info
+   ```
+4. Inspect the `my_info` / `nodes` section for the local node.
+
+### Pass criteria
+- `locationSource` = `LOC_INTERNAL` (not `LOC_MANUAL` or absent).
+- `latitude` ≈ 25.052103 (±0.001°).
+- `longitude` ≈ 121.574039 (±0.001°).
+- `altitude` ≈ 50 m.
+- `time` field (Unix epoch) matches approximately `1745625600 + uptime_s`.
+
+---
+
+## Test 3 — RTC disciplines from GPS epoch
+
+Verify that `perhapsSetRTC(RTCQualityGPS, ...)` has run and the modem's
+wall clock reflects the GPS epoch.
+
+### Procedure
+
+1. After Test 2 passes, run:
+   ```sh
+   python -m meshtastic --port <COMxx> --info
+   ```
+2. Check `myInfo.reboot_count` or any field with a `time` component.
+3. Alternatively, inspect the Meshtastic debug log line beginning with
+   `Set RTC quality=GPS` (visible over USB CDC at baud 115200):
+   ```sh
+   python -m meshtastic --port <COMxx> --listen
+   ```
+   Expected log fragment:
+   ```
+   Set RTC quality=GPS to <unix_epoch>
+   ```
+
+### Pass criteria
+- The RTC log line appears within 5 s of boot with `quality=GPS`.
+- The Unix epoch in the log matches the dummy injector's `DUMMY_UNIX_BASE +
+  uptime_s` to within ±2 s.
+
+---
+
+## Test 4 — PositionModule broadcasts to mesh
+
+Verify that the local node transmits its position to mesh neighbours.
+
+### Procedure
+
+1. Have a second Meshtastic node within RF range.
+2. Flash Core 0 + Core 1 on the DUT (MokyaLora).
+3. On the second node, run:
+   ```sh
+   python -m meshtastic --port <second_node_port> --info
+   ```
+4. Look for the DUT node in the `nodes` list on the second node.
+
+### Pass criteria
+- The DUT's node entry on the second node includes position data matching
+  the dummy coordinates.
+- `locationSource` = `LOC_INTERNAL` on the remote node's copy of the DUT
+  node info.
+
+---
+
+## Test 5 — Real Teseo integration (deferred, `MOKYA_GPS_DUMMY_NMEA=OFF`)
+
+Once outdoor testing is available:
+
+1. Build with `MOKYA_GPS_DUMMY_NMEA=OFF` (default).
+2. Bring the board outdoors, wait for GNSS cold-start fix (≤ 90 s typical).
+3. Run `python -m meshtastic --info` and verify:
+   - `latitude` / `longitude` match the actual location (±50 m HDOP circle).
+   - `time` matches real UTC to within ±2 s.
+   - `sats_in_view` ≥ 4.
+
+---
+
+## SWD IpcGpsBuf address derivation
+
+If the map file lookup is preferred over manual arithmetic:
+
+```sh
+# From repo root, after a successful Core 0 build:
+MAP=firmware/core0/meshtastic/.pio/build/rp2350b-mokya/firmware.elf
+arm-none-eabi-nm -n "$MAP" | grep g_ipc_shared
+```
+
+`g_ipc_shared` is the singleton `IpcSharedSram` placed in `.shared_ipc_sram`
+(linker section `NOLOAD` at `0x2007A000`).  The `gps_buf` field offset within
+`IpcSharedSram` can be read from the struct layout (see `ipc_shared_layout.h`
+`_Static_assert` guards).
+
+---
+
+## Known limitations
+
+- The dummy injector produces a static position; actual position tracking
+  requires Test 5 with real Teseo output.
+- `PositionModule::runOnce()` broadcasts on its own interval (default
+  `position_broadcast_secs` = 900 s); it can be forced with
+  `positionModule->sendOurPosition()` over the Meshtastic admin interface.
+- `IpcGpsStream` is now a permanent no-op; any NMEA-based GPS probe path is
+  fully disabled.  GPS module state is set to `connected` by the
+  `MOKYA_IPC_GPS_STREAM` init hook in variant.cpp; this is required to
+  keep `PositionModule` from disabling itself.

--- a/firmware/core1/src/sensor/gps_dummy.c
+++ b/firmware/core1/src/sensor/gps_dummy.c
@@ -1,17 +1,16 @@
-/* gps_dummy.c — Fixed-position NMEA GGA injector for IpcGpsBuf validation.
+/* gps_dummy.c — Fixed-position structured fix injector for IpcGpsBuf validation.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Builds one $GPGGA sentence per second with a runtime-computed checksum
- * and a slowly-incrementing UTC field, then commits it into the shared-SRAM
- * IpcGpsBuf double-buffer.
+ * Writes one IpcGpsFixSlot per second with a slowly-incrementing unix_epoch
+ * and fixed Taipei coordinates into the shared-SRAM IpcGpsBuf double-buffer.
+ * Replaces the earlier NMEA sentence injector (M3.5) now that IpcGpsBuf holds
+ * structured fix data instead of raw NMEA bytes (M5).
  */
 
 #include "gps_dummy.h"
 
-#include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "FreeRTOS.h"
@@ -20,100 +19,18 @@
 #include "ipc_shared_layout.h"
 #include "ipc_protocol.h"
 
-#define DUMMY_PERIOD_MS 500u  /* Alternates GGA / RMC each tick → 1 Hz per type */
+#define DUMMY_PERIOD_MS   1000u       /* One structured fix per second */
+#define DUMMY_UNIX_BASE   1745625600u /* 2026-04-26 00:00:00 UTC */
 
-/* Taipei fixed coordinates (user-supplied for M3.5 dummy validation). */
-#define DUMMY_LAT_DEG    25
-#define DUMMY_LAT_MIN_X1E5  312618u   /* (25.052103 - 25) * 60 * 100000 = 312618 */
-#define DUMMY_LON_DEG    121
-#define DUMMY_LON_MIN_X1E5  3444234u  /* (121.574039 - 121) * 60 * 100000 = 3444234 */
-#define DUMMY_ALT_DM     500          /* 50.0 m, expressed in decimetres for printf */
-#define DUMMY_FIX_QUALITY 1           /* 1 = GPS fix */
-#define DUMMY_NUM_SATS    8
-#define DUMMY_HDOP_X10    9           /* 0.9 */
+/* Taipei fixed coordinates (25.052103 N, 121.574039 E). */
+#define DUMMY_LAT_E7     250521030
+#define DUMMY_LON_E7    1215740390
+#define DUMMY_ALT_MM     50000       /* 50 m above MSL */
+#define DUMMY_HDOP_X100  90          /* HDOP 0.90 */
+#define DUMMY_SAT_COUNT  8
+#define DUMMY_FIX_QUALITY 1          /* GPS fix */
 
-static uint32_t s_seconds;            /* Monotonic seconds since task start */
-
-static uint8_t nmea_checksum(const char *body, size_t len)
-{
-    uint8_t cs = 0;
-    for (size_t i = 0; i < len; ++i) {
-        cs ^= (uint8_t)body[i];
-    }
-    return cs;
-}
-
-/* Common helper: wrap body with leading '$' and trailing '*XX\r\n'. */
-static int finalize_nmea(char *out, size_t cap, const char *body, size_t body_len)
-{
-    uint8_t cs = nmea_checksum(body, body_len);
-    int total = snprintf(out, cap, "$%s*%02X\r\n", body, cs);
-    if (total <= 0 || (size_t)total >= cap) return -1;
-    return total;
-}
-
-/* GGA — position + fix quality + altitude. Time only (no date). */
-static int format_gga(char *out, size_t cap, uint32_t seconds_since_boot)
-{
-    uint32_t t = seconds_since_boot % 86400u;
-    unsigned hh = (unsigned)(t / 3600u);
-    unsigned mm = (unsigned)((t / 60u) % 60u);
-    unsigned ss = (unsigned)(t % 60u);
-
-    char body[96];
-    int body_len = snprintf(body, sizeof(body),
-        "GPGGA,%02u%02u%02u.00,"
-        "%02u%02u.%05lu,N,"
-        "%03u%02u.%05lu,E,"
-        "%u,%02u,%u.%u,"
-        "%d.%d,M,0.0,M,,",
-        hh, mm, ss,
-        (unsigned)DUMMY_LAT_DEG,
-        (unsigned)(DUMMY_LAT_MIN_X1E5 / 100000u),
-        (unsigned long)(DUMMY_LAT_MIN_X1E5 % 100000u),
-        (unsigned)DUMMY_LON_DEG,
-        (unsigned)(DUMMY_LON_MIN_X1E5 / 100000u),
-        (unsigned long)(DUMMY_LON_MIN_X1E5 % 100000u),
-        (unsigned)DUMMY_FIX_QUALITY,
-        (unsigned)DUMMY_NUM_SATS,
-        (unsigned)(DUMMY_HDOP_X10 / 10u),
-        (unsigned)(DUMMY_HDOP_X10 % 10u),
-        (int)(DUMMY_ALT_DM / 10),
-        (int)(DUMMY_ALT_DM % 10));
-
-    if (body_len <= 0 || (size_t)body_len >= sizeof(body)) return -1;
-    return finalize_nmea(out, cap, body, (size_t)body_len);
-}
-
-/* RMC — recommended-minimum sentence with date. Meshtastic's lookForLocation
- * rejects fixes whose `date` is too old (line 1772 of GPS.cpp), so we have
- * to publish a date even though the dummy clock has no real wall time. Use
- * a fixed 2026-04-26 — the date is just a TinyGPS validity gate, not a
- * value that gets surfaced to the user. */
-static int format_rmc(char *out, size_t cap, uint32_t seconds_since_boot)
-{
-    uint32_t t = seconds_since_boot % 86400u;
-    unsigned hh = (unsigned)(t / 3600u);
-    unsigned mm = (unsigned)((t / 60u) % 60u);
-    unsigned ss = (unsigned)(t % 60u);
-
-    char body[96];
-    int body_len = snprintf(body, sizeof(body),
-        "GPRMC,%02u%02u%02u.00,A,"
-        "%02u%02u.%05lu,N,"
-        "%03u%02u.%05lu,E,"
-        "0.00,0.00,260426,,,A",
-        hh, mm, ss,
-        (unsigned)DUMMY_LAT_DEG,
-        (unsigned)(DUMMY_LAT_MIN_X1E5 / 100000u),
-        (unsigned long)(DUMMY_LAT_MIN_X1E5 % 100000u),
-        (unsigned)DUMMY_LON_DEG,
-        (unsigned)(DUMMY_LON_MIN_X1E5 / 100000u),
-        (unsigned long)(DUMMY_LON_MIN_X1E5 % 100000u));
-
-    if (body_len <= 0 || (size_t)body_len >= sizeof(body)) return -1;
-    return finalize_nmea(out, cap, body, (size_t)body_len);
-}
+static uint32_t s_seconds;
 
 static void gps_dummy_task(void *pv)
 {
@@ -121,36 +38,27 @@ static void gps_dummy_task(void *pv)
 
     IpcGpsBuf *gps = &g_ipc_shared.gps_buf;
 
-    /* Reset to a known state — boot_magic init zeroed the region, but be
-     * explicit so re-spawning the task (future debug) starts clean. */
+    /* Reset to a known state — explicit in case task is ever re-spawned. */
     gps->write_idx = 0;
-    gps->len[0] = 0;
-    gps->len[1] = 0;
+    memset(gps->slot, 0, sizeof(gps->slot));
 
     TickType_t last = xTaskGetTickCount();
-    bool send_rmc = false;
     for (;;) {
-        char sentence[128];
-        int n;
-        if (send_rmc) {
-            n = format_rmc(sentence, sizeof(sentence), s_seconds);
-        } else {
-            n = format_gga(sentence, sizeof(sentence), s_seconds);
-            ++s_seconds;  /* Bump the second once per GGA/RMC pair. */
-        }
-        send_rmc = !send_rmc;
-
-        if (n > 0 && (size_t)n <= sizeof(gps->buf[0])) {
-            /* Per ipc_protocol.h IpcGpsBuf contract: write_idx is the slot
-             * Core 1 currently owns; reader (Core 0) reads buf[write_idx ^ 1].
-             * So we write into buf[write_idx], then flip write_idx — that
-             * makes the just-finished slot visible to the reader as
-             * buf[(new write_idx) ^ 1]. */
-            uint8_t cur = gps->write_idx;
-            memcpy(gps->buf[cur], sentence, (size_t)n);
-            gps->len[cur] = (uint8_t)n;
-            __atomic_store_n(&gps->write_idx, (uint8_t)(cur ^ 1u), __ATOMIC_RELEASE);
-        }
+        /* Write structured fix into the currently-owned slot, then flip
+         * write_idx to publish.  Reader (Core 0) sees slot[write_idx ^ 1]
+         * as the most-recently-published snapshot. */
+        uint8_t cur = gps->write_idx;
+        IpcGpsFixSlot *slot = &gps->slot[cur];
+        slot->unix_epoch  = DUMMY_UNIX_BASE + s_seconds++;
+        slot->lat_e7      = DUMMY_LAT_E7;
+        slot->lon_e7      = DUMMY_LON_E7;
+        slot->altitude_mm = DUMMY_ALT_MM;
+        slot->hdop_x100   = DUMMY_HDOP_X100;
+        slot->sat_count   = DUMMY_SAT_COUNT;
+        slot->fix_quality = DUMMY_FIX_QUALITY;
+        slot->fix_valid   = 1u;
+        memset(slot->_pad, 0, sizeof(slot->_pad));
+        __atomic_store_n(&gps->write_idx, (uint8_t)(cur ^ 1u), __ATOMIC_RELEASE);
 
         vTaskDelayUntil(&last, pdMS_TO_TICKS(DUMMY_PERIOD_MS));
     }
@@ -158,9 +66,8 @@ static void gps_dummy_task(void *pv)
 
 bool gps_dummy_start(UBaseType_t priority)
 {
-    /* 384 words (1.5 KB). snprintf draws ~400 B of libc frame + a 96 B
-     * body buffer + 128 B sentence buffer — comfortably within budget. */
-    BaseType_t rc = xTaskCreate(gps_dummy_task, "gps_dummy", 384,
+    /* 256 words (1 KB). No NMEA formatting, no libc frame needed. */
+    BaseType_t rc = xTaskCreate(gps_dummy_task, "gps_dummy", 256,
                                 NULL, priority, NULL);
     return rc == pdPASS;
 }

--- a/firmware/core1/src/sensor/gps_task.c
+++ b/firmware/core1/src/sensor/gps_task.c
@@ -14,6 +14,9 @@
 #include "gps_dummy.h"
 #else
 #include "teseo_liv3fl.h"
+#include "ipc_shared_layout.h"
+#include "ipc_protocol.h"
+#include "wall_clock.h"
 #endif
 
 #define DRAIN_PERIOD_MS  100u
@@ -27,6 +30,51 @@ volatile uint32_t g_rf_commission_rc;
 #endif
 
 #ifndef MOKYA_GPS_DUMMY_NMEA
+
+/* Writes the current Teseo fix into IpcGpsBuf if the parsed state is
+ * newer than the last commit (tracked via sentence_count). Called after
+ * every teseo_poll() so latency from NMEA → shared SRAM is ≤ 100 ms. */
+static uint32_t s_last_sentence_count;
+
+static void ipc_gps_commit_fix(void)
+{
+    const teseo_state_t *s = teseo_get_state();
+    if (!s->fix_valid || s->fix_quality == 0) return;
+    if (s->sentence_count == s_last_sentence_count) return;
+    if (s->utc_date == 0 || s->utc_time == 0) return;
+    s_last_sentence_count = s->sentence_count;
+
+    /* Convert Teseo utc_date (ddmmyy) + utc_time (hhmmss) to Unix epoch. */
+    wall_clock_civil_t civil;
+    civil.year   = (uint16_t)(2000u + s->utc_date % 100u);
+    civil.month  = (uint8_t)((s->utc_date / 100u) % 100u);
+    civil.day    = (uint8_t)(s->utc_date / 10000u);
+    civil.hour   = (uint8_t)(s->utc_time / 10000u);
+    civil.minute = (uint8_t)((s->utc_time / 100u) % 100u);
+    civil.second = (uint8_t)(s->utc_time % 100u);
+    civil.reserved = 0u;
+    uint64_t epoch = wall_clock_civil_to_unix(&civil);
+
+    /* Write structured fix into the currently-owned IpcGpsBuf slot,
+     * then flip write_idx to publish the snapshot atomically. */
+    IpcGpsBuf *gps = &g_ipc_shared.gps_buf;
+    uint8_t cur = gps->write_idx;
+    IpcGpsFixSlot *slot = &gps->slot[cur];
+    slot->unix_epoch  = (uint32_t)epoch;
+    slot->lat_e7      = s->lat_e7;
+    slot->lon_e7      = s->lon_e7;
+    slot->altitude_mm = (int32_t)s->altitude_m * 1000;
+    slot->hdop_x100   = (uint16_t)((uint32_t)s->hdop_x10 * 10u);
+    slot->sat_count   = s->num_sats;
+    slot->fix_quality = s->fix_quality;
+    slot->fix_valid   = s->fix_valid ? 1u : 0u;
+    slot->_pad[0] = slot->_pad[1] = slot->_pad[2] = 0u;
+    __atomic_store_n(&gps->write_idx, (uint8_t)(cur ^ 1u), __ATOMIC_RELEASE);
+
+    /* Sync Core 1 soft wall clock from GNSS. */
+    wall_clock_set_unix_from_gnss(epoch);
+}
+
 static void gps_task(void *pv)
 {
     (void)pv;
@@ -50,6 +98,7 @@ static void gps_task(void *pv)
     TickType_t last = xTaskGetTickCount();
     for (;;) {
         (void)teseo_poll();
+        ipc_gps_commit_fix();
         vTaskDelayUntil(&last, pdMS_TO_TICKS(DRAIN_PERIOD_MS));
     }
 }

--- a/firmware/shared/ipc/ipc_protocol.h
+++ b/firmware/shared/ipc/ipc_protocol.h
@@ -148,20 +148,40 @@ typedef struct {
 /* ── GPS bridge (shared SRAM, not FIFO) ──────────────────────────────────── */
 
 /**
- * IpcGpsBuf — double-buffer for NMEA sentences written by Core 1, read by Core 0.
+ * IpcGpsFixSlot — one parsed GPS fix snapshot (24 bytes).
  *
- * Core 1 owns the Teseo-LIV3FL on the sensor bus (i2c1, GPIO 34/35). It writes
- * complete NMEA sentences into buf[write_idx ^ 1] while Core 0 reads buf[write_idx ^ 1]
- * after the flip. No doorbell is sent — the atomic flip of write_idx is itself the
- * signal; Core 0 polls the index on its 1 Hz cadence.
- *
- * Each slot holds one NMEA sentence (max 82 bytes per NMEA spec, padded to 128).
+ * Populated by Core 1 from the Teseo-LIV3FL parsed state after each new fix.
+ * Core 0 reads the most-recently-published slot via IpcGpsBuf.write_idx ^ 1.
  */
 typedef struct {
-    uint8_t  buf[2][128];           ///< Double buffer: [0] and [1] slots
-    uint8_t  write_idx;             ///< Index Core 1 is currently writing into (0 or 1)
-    uint8_t  len[2];                ///< Valid byte count in each slot
-    uint8_t  _pad[1];               ///< Pads to 260 B to match shared-SRAM reservation
+    uint32_t unix_epoch;    ///< UTC Unix seconds since 1970; 0 = no valid fix
+    int32_t  lat_e7;        ///< Latitude × 1e7 degrees (positive = North)
+    int32_t  lon_e7;        ///< Longitude × 1e7 degrees (positive = East)
+    int32_t  altitude_mm;   ///< Altitude above MSL in millimetres
+    uint16_t hdop_x100;     ///< HDOP × 100 (e.g. 120 = HDOP 1.20)
+    uint8_t  sat_count;     ///< Number of satellites used
+    uint8_t  fix_quality;   ///< 0=none 1=GPS 2=DGPS (from GGA)
+    uint8_t  fix_valid;     ///< 1 = RMC status 'A' (data valid)
+    uint8_t  _pad[3];       ///< Alignment padding, reserved zero
+} IpcGpsFixSlot;
+_Static_assert(sizeof(IpcGpsFixSlot) == 24, "IpcGpsFixSlot must be 24 B");
+
+/**
+ * IpcGpsBuf — double-buffer of structured fix snapshots (260 bytes total).
+ *
+ * Core 1 writes a fully-parsed IpcGpsFixSlot into slot[write_idx], then
+ * atomically flips write_idx — that makes the freshly-written slot visible
+ * to Core 0 as slot[write_idx ^ 1].  No doorbell is sent; Core 0 polls
+ * write_idx at ~1 Hz and checks for a new value.
+ *
+ * Replaces the earlier raw-NMEA double-buffer (M3.5) with structured data
+ * so Core 0 can call perhapsSetRTC() and nodeDB->setLocalPosition() without
+ * running a NMEA parser on the modem core (M5).
+ */
+typedef struct {
+    IpcGpsFixSlot slot[2];          ///< Double buffer: [0] and [1] fix slots (48 B)
+    volatile uint8_t write_idx;     ///< Slot Core 1 last wrote into (0 or 1)
+    uint8_t  _pad[211];             ///< Reserved, zero-initialised → total 260 B
 } IpcGpsBuf;
 _Static_assert(sizeof(IpcGpsBuf) == 260, "IpcGpsBuf must be exactly 260 bytes");
 


### PR DESCRIPTION
## Summary

Replaces the M3.5 raw-NMEA `IpcGpsBuf` with a structured `IpcGpsFixSlot` double-buffer so Core 0 can discipline its RTC and broadcast position to the mesh without running a NMEA parser on the modem core.

### Deliverable 1 — Core 1 writer (`gps_task.c`, `gps_dummy.c`)
- `ipc_gps_commit_fix()` runs after every `teseo_poll()` (100 ms cadence), deduplicated by `sentence_count`. Converts Teseo `utc_date`/`utc_time` → Unix epoch via `wall_clock_civil_to_unix()`, writes `IpcGpsFixSlot`, flips `write_idx` atomically (`__ATOMIC_RELEASE`), then calls `wall_clock_set_unix_from_gnss()`.
- `gps_dummy.c` rewritten: emits one `IpcGpsFixSlot` per second (fixed Taipei coords, `DUMMY_UNIX_BASE = 1745625600`). No NMEA formatting — stack drops from 384 W to 256 W.

### Deliverable 2 — Core 0 consumer (`ipc_gps_consumer.{h,cpp}`)
- `IpcGpsConsumer` OSThread (`runOnce` = 1 s) reads `slot[write_idx ^ 1]`.
- Calls `perhapsSetRTC(RTCQualityGPS, &tv)` (priority 4 = highest).
- Calls `nodeDB->setLocalPosition(pos)` → `PositionModule::runOnce()` auto-broadcasts.
- Registered from `vApplicationIdleHook` first-run block (after `setup()` completes, before Core 1 launch) so the OSThread scheduler is live.

### Deliverable 3 — Test plan
`docs/bringup/m5-gps-ipc-test-plan.md` — 5-step plan: SWD memory read, `--info` position check, RTC log line, mesh broadcast, real Teseo integration.

## IpcGpsBuf layout (unchanged 260 B total)

```c
typedef struct {
    uint32_t unix_epoch;   // UTC seconds since 1970; 0 = invalid
    int32_t  lat_e7;       // latitude  × 1e7 degrees
    int32_t  lon_e7;       // longitude × 1e7 degrees
    int32_t  altitude_mm;  // altitude above MSL in mm
    uint16_t hdop_x100;    // HDOP × 100
    uint8_t  sat_count;
    uint8_t  fix_quality;  // 0=none 1=GPS 2=DGPS
    uint8_t  fix_valid;    // RMC status 'A'
    uint8_t  _pad[3];
} IpcGpsFixSlot;           // 24 B (_Static_assert)

typedef struct {
    IpcGpsFixSlot slot[2]; // 48 B
    volatile uint8_t write_idx; // 1 B
    uint8_t _pad[211];     // → 260 B total (_Static_assert)
} IpcGpsBuf;
```

## Also fixed

- **M5E.3 regression** (`platformio.ini`): removes three stale `build_src_filter` entries (`ipc_text_observer.cpp`, `ipc_ack_observer.cpp`, `ipc_node_observer.cpp`) that were deleted in submodule commit `bed833eb9` but left in the filter — this was breaking the Core 0 PlatformIO build.
- `ipc_gps_stream.cpp` made a permanent no-op; `MOKYA_IPC_GPS_STREAM=1` kept to preserve the `GPS.cpp` init path (probe-skip, `GNSS_MODEL_UNKNOWN`).

## Test plan

See `docs/bringup/m5-gps-ipc-test-plan.md` for full SWD + CLI verification steps.

Quick smoke test with dummy injector:
```sh
bash scripts/build_and_flash.sh   # Core 1 needs -DMOKYA_GPS_DUMMY_NMEA=ON
python -m meshtastic --port <COM> --info
# Expect: latitude ≈ 25.052103, longitude ≈ 121.574039, locationSource = LOC_INTERNAL
```

## Submodule note

Core 0 variant files are in submodule `firmware/core0/meshtastic` (repo `tengigabytes/firmware`). The submodule commit `0f26c8082` is on branch `feat/rp2350b-mokya` locally but needs to be pushed:

```sh
cd firmware/core0/meshtastic
git push -u origin feat/rp2350b-mokya
```

The outer repo submodule pointer in this PR already references that commit SHA.

https://claude.ai/code/session_017JARrLvFhTWaujjZDXnzgC

---
_Generated by [Claude Code](https://claude.ai/code/session_017JARrLvFhTWaujjZDXnzgC)_